### PR TITLE
feat(cli): implement CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,25 @@ prettierTransform("foo()", [myTransform], {
   semi: false
 });
 ```
+
+## Writing Transforms
+
+Transforms must be standard JavaScript modules that export a function that takes
+an AST and returns an AST.
+
+If you're working with a babylon-produced AST, you can do the following:
+
+```js
+const traverse = require("babel-traverse").default;
+
+module.exports = ast => {
+  traverse(ast, {
+    Identifier(path) {
+      if (path.node.name === "foo") {
+        path.node.name = "bar";
+      }
+    }
+  });
+  return ast;
+};
+```

--- a/README.md
+++ b/README.md
@@ -5,4 +5,42 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 
-TODO(azz): docs :)
+## Install
+
+```bash
+yarn add --dev prettier-transform
+```
+
+## CLI Usage
+
+Basic usage:
+
+```bash
+prettier-transform file.js --parser babylon -t ./my-transform
+```
+
+Unknown options will be passed to prettier:
+
+```bash
+prettier-transform file.js --parser babylon -t ./my-transform --no-semi
+```
+
+## API Usage
+
+Basic usage:
+
+```js
+const prettierTransform = require("prettier-transform");
+const myTransform = require("./my-transform");
+
+prettierTransform("foo()", [myTransform], { parser: "babylon" });
+```
+
+Pass options to prettier:
+
+```js
+prettierTransform("foo()", [myTransform], {
+  parser: "babylon",
+  semi: false
+});
+```

--- a/bin/prettier-transform.js
+++ b/bin/prettier-transform.js
@@ -2,5 +2,75 @@
 
 "use strict";
 
-// TODO(azz):
+const camelcaseKeys = require("camelcase-keys");
+const minimist = require("minimist");
+const resolve = require("resolve");
+const assert = require("assert");
+const globby = require("globby");
+const path = require("path");
+const fs = require("fs");
 
+const prettierTransform = require("../");
+
+const args = normalizeArgs(parseArgv(process.argv.slice(2)));
+
+assert.ok(typeof args.parser === "string", "--parser must be a string");
+
+const transforms = args.transform.map(loadTransform);
+const filePaths = getFilePaths(args.patterns);
+
+delete args.prettierOptions.t;
+delete args.prettierOptions._;
+
+for (const code of filePaths.map(readFile)) {
+  const output = prettierTransform.format(
+    code,
+    transforms,
+    Object.assign({}, args.prettierOptions, {
+      parser: args.parser
+    })
+  );
+  console.log(output);
+}
+
+function parseArgv(argv) {
+  return minimist(argv, {
+    string: ["t", "parser"],
+    default: {
+      t: []
+    }
+  });
+}
+
+function normalizeArgs(args) {
+  return Object.assign({}, args, {
+    transform: [].concat(args.t || []),
+    patterns: [].concat(args._ || []),
+    prettierOptions: camelcaseKeys(args)
+  });
+}
+
+function getFilePaths(patterns) {
+  return globby
+    .sync(patterns, { dot: true })
+    .map(
+      filePath =>
+        path.isAbsolute(filePath)
+          ? path.relative(process.cwd(), filePath)
+          : filePath
+    );
+}
+
+function loadTransform(modulePath) {
+  const fsPath = resolve.sync(modulePath, { basedir: process.cwd() });
+  return require(fsPath);
+}
+
+function readFile(filePath) {
+  return fs.readFileSync(
+    path.isAbsolute(filePath)
+      ? filePath
+      : path.relative(process.cwd(), filePath),
+    "utf8"
+  );
+}

--- a/bin/prettier-transform.js
+++ b/bin/prettier-transform.js
@@ -30,7 +30,7 @@ for (const code of filePaths.map(readFile)) {
       parser: args.parser
     })
   );
-  console.log(output);
+  console.log(output); // eslint-disable-line no-console
 }
 
 function parseArgv(argv) {

--- a/index.test.js
+++ b/index.test.js
@@ -55,6 +55,13 @@ describe("format()", () => {
     return ast;
   };
 
+  it("applies a single transform", () => {
+    const output = prettierTransform.format("foo()", [replaceFooWithBar], {
+      parser: "babylon"
+    });
+    expect(output).toEqual("bar();\n");
+  });
+
   it("applies multiple transforms in order", () => {
     const output = prettierTransform.format(
       "foo()",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",
     "jest": "^21.2.1",
+    "minimist": "^1.2.0",
     "prettier": "1.7.2",
     "semantic-release": "^8.0.3"
   },
@@ -27,5 +28,10 @@
     "format": "prettier --write \"**/*.js\"",
     "lint": "eslint .",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "dependencies": {
+    "camelcase-keys": "^4.1.0",
+    "globby": "^6.1.0",
+    "resolve": "^1.4.0"
   }
 }

--- a/test/__snapshots__/cli.test.js.snap
+++ b/test/__snapshots__/cli.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cli applies a transform to a file 1`] = `
+",/* eslint-disable */
+bar();
+
+,"
+`;
+
+exports[`cli passes unknown options to prettier 1`] = `
+",/* eslint-disable */
+bar()
+
+,"
+`;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,35 @@
+"use strict";
+
+describe("cli", () => {
+  test("applies a transform to a file", () => {
+    const result = run([
+      "-t=./test/transform-foo-to-bar",
+      "--parser=babylon",
+      "./test/foo.js"
+    ]);
+    expectPass(result);
+    expect(result.output.toString()).toMatchSnapshot();
+  });
+
+  test("passes unknown options to prettier", () => {
+    const result = run([
+      "-t=./test/transform-foo-to-bar",
+      "--parser=babylon",
+      "./test/foo.js",
+      "--no-semi"
+    ]);
+    expectPass(result);
+    expect(result.output.toString()).toMatchSnapshot();
+  });
+});
+
+const spawnSync = require("child_process").spawnSync;
+
+function run(args) {
+  return spawnSync("node", ["./bin/prettier-transform.js"].concat(args));
+}
+
+function expectPass(result) {
+  expect(result.error).toBeFalsy();
+  expect(result.stderr.toString()).toEqual("");
+}

--- a/test/foo.js
+++ b/test/foo.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+foo();

--- a/test/transform-foo-to-bar.js
+++ b/test/transform-foo-to-bar.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const traverse = require("babel-traverse").default;
+
+module.exports = ast => {
+  traverse(ast, {
+    Identifier(path) {
+      if (path.node.name === "foo") {
+        path.node.name = "bar";
+      }
+    }
+  });
+  return ast;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,6 +507,14 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.1.0.tgz#214d348cc5457f39316a2c31cc3e37246325e73f"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -1355,6 +1363,16 @@ globby@^5.0.0:
   dependencies:
     array-union "^1.0.1"
     arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
     glob "^7.0.3"
     object-assign "^4.0.1"
     pify "^2.0.0"
@@ -2290,6 +2308,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -2787,6 +2809,10 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3001,6 +3027,12 @@ resolve-from@^3.0.0:
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is more proof-of-concept work than an API I think will be maintainable. I've had to re-implement some of the work prettier does to parse args and load files, and I haven't implemented `--write`. 

But this should be enough to get the ball rolling and see if people want to use this kind of tool.
